### PR TITLE
I've fixed a hydration error in the `ProjectInput` component.

### DIFF
--- a/apps/web/components/project-input-redesigned.tsx
+++ b/apps/web/components/project-input-redesigned.tsx
@@ -32,13 +32,15 @@ export function ProjectInput({
   const [isDragOver, setIsDragOver] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [clientSupportsFileSystemAPI, setClientSupportsFileSystemAPI] = useState(false);
 
-  // Проверка поддержки File System API
-  const supportsFileSystemAPI = typeof window !== 'undefined' && 'showDirectoryPicker' in window;
+  React.useEffect(() => {
+    setClientSupportsFileSystemAPI(typeof window !== 'undefined' && 'showDirectoryPicker' in window);
+  }, []);
 
   // Выбор папки через File System API
   const handleSelectFolder = useCallback(async () => {
-    if (!supportsFileSystemAPI) {
+    if (!clientSupportsFileSystemAPI) {
       fileInputRef.current?.click();
       return;
     }
@@ -69,7 +71,7 @@ export function ProjectInput({
         console.error('Ошибка выбора папки:', err);
       }
     }
-  }, [supportsFileSystemAPI, setProjectPath]);
+  }, [clientSupportsFileSystemAPI, setProjectPath]);
 
   // Fallback для браузеров без File System API
   const handleFileInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
@@ -245,7 +247,7 @@ export function ProjectInput({
                   Выбрать папку
                 </Button>
 
-                {!supportsFileSystemAPI && (
+                {!clientSupportsFileSystemAPI && (
                   <Button
                     variant="outline"
                     onClick={() => fileInputRef.current?.click()}


### PR DESCRIPTION
This error was caused by a mismatch between the server-rendered HTML and the initial client-side render. This happened because the component immediately checked for File System API support, which behaves differently on the server and the client.

Here's how I addressed it:
- I removed the immediate check for File System API support.
- I introduced a new state variable, `clientSupportsFileSystemAPI`, initialized to `false`.
- I added a `React.useEffect` hook to check for File System API support only on the client-side after the component has mounted. This hook updates the `clientSupportsFileSystemAPI` state.
- I modified the `handleSelectFolder` function and the conditional rendering of the "Загрузить файлы" (Upload files) button to use the `clientSupportsFileSystemAPI` state.

This approach ensures that the server-rendered output and the initial client-side render are consistent. The UI then adjusts based on actual client capabilities after hydration, preventing the mismatch.

Additionally, an error related to `ExportDialog.tsx` was noted. I searched for `ExportDialog.tsx` within the repository but couldn't locate the file. This could be due to a stale error message, the file being generated during the build process, or it being part of an external module. Further investigation may be needed if this error persists after resolving the hydration issue.